### PR TITLE
fixes #6: Add evaluator for Task Engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>threaddump</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>Threaddump Plugin</name>
     <description>A plugin that can be used to generate diagnostics.</description>

--- a/src/changelog.html
+++ b/src/changelog.html
@@ -45,16 +45,15 @@ Threaddump Plugin Changelog
 </h1>
 
 
-<p><b>1.0.2</b> -- TBD</p>
+<p><b>1.1.0</b> -- (tbd)</p>
 <ul>
+    <li>Added new evaluator for TaskEngine</li>
 </ul>
-
 
 <p><b>1.0.1</b> -- January 12, 2021</p>
 <ul>
      <li><a href="https://github.com/igniterealtime/openfire-threaddump-plugin/pull/4">#4</a> Fix Maven groupId</li>
 </ul>
-
 
 <p><b>1.0.0</b> -- August 2, 2019</p>
 <ul>

--- a/src/main/i18n/threaddump_i18n.properties
+++ b/src/main/i18n/threaddump_i18n.properties
@@ -29,6 +29,13 @@ threaddump.page.task.pools.successive-hits=How many successive evaluations must 
 
 threaddump.page.task.deadlock.title=Settings for evaluation of thread deadlocks
 threaddump.page.task.deadlock.enabled=Generate a thread dump when a deadlock is detected.
-threaddump.page.task.deadlock.interval=The frequence of deadlock detection.
+threaddump.page.task.deadlock.interval=The frequency of deadlock detection.
+
+threaddump.page.task.taskengine.title=Settings for evaluation of the threads pool of the Openfire Task Engine
+threaddump.page.task.taskengine.enabled=Generate a thread dump when the thread pool is very busy.
+threaddump.page.task.taskengine.max-threads=The minimum amount of active threads in the pool to trigger a thread dump.
+threaddump.page.task.taskengine.max-poolsize=The minimum size of the thread pool (including active and inactive threads) to trigger a thread dump.
+threaddump.page.task.taskengine.interval=The frequency Task Engine's thread pool evaluation.
+threaddump.page.task.taskengine.successive-hits=How many successive evaluations must have detected excessive thread pool usage, for a thread dump to be created.
 
 settings.saved.successfully=Settings successfully saved!

--- a/src/main/java/org/igniterealtime/openfire/plugin/threaddump/DumpCheckTimerTask.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/threaddump/DumpCheckTimerTask.java
@@ -15,23 +15,18 @@
  */
 package org.igniterealtime.openfire.plugin.threaddump;
 
-import org.apache.mina.core.filterchain.DefaultIoFilterChainBuilder;
-import org.apache.mina.filter.executor.ExecutorFilter;
-import org.apache.mina.transport.socket.nio.NioSocketAcceptor;
 import org.igniterealtime.openfire.plugin.threaddump.evaluator.Evaluator;
 import org.igniterealtime.openfire.plugin.threaddump.formatter.DefaultThreadDumpFormatter;
-import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.openfire.spi.ConnectionListener;
-import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.*;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 
 /**

--- a/src/main/java/org/igniterealtime/openfire/plugin/threaddump/ThreadDumpPlugin.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/threaddump/ThreadDumpPlugin.java
@@ -18,6 +18,7 @@ package org.igniterealtime.openfire.plugin.threaddump;
 import org.igniterealtime.openfire.plugin.threaddump.evaluator.CoreThreadPoolsEvaluator;
 import org.igniterealtime.openfire.plugin.threaddump.evaluator.DeadlockEvaluator;
 import org.igniterealtime.openfire.plugin.threaddump.evaluator.Evaluator;
+import org.igniterealtime.openfire.plugin.threaddump.evaluator.TaskEngineEvaluator;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.util.JiveGlobals;
@@ -169,7 +170,7 @@ public class ThreadDumpPlugin implements Plugin, PropertyEventListener
     public Set<Class<? extends Evaluator>> getTaskEvaluatorClasses()
     {
         final Set<Class<? extends Evaluator>> result = new HashSet<>();
-        final String evaluatorNames = JiveGlobals.getProperty( "threaddump.task.evaluators", CoreThreadPoolsEvaluator.class.getCanonicalName() + ", " + DeadlockEvaluator.class.getCanonicalName() );
+        final String evaluatorNames = JiveGlobals.getProperty( "threaddump.task.evaluators", CoreThreadPoolsEvaluator.class.getCanonicalName() + ", " + DeadlockEvaluator.class.getCanonicalName() + ", " + TaskEngineEvaluator.class.getCanonicalName() );
         if ( evaluatorNames != null ) {
             for ( final String evaluatorName : evaluatorNames.split( "\\s*,\\s*" ) )
             {

--- a/src/main/java/org/igniterealtime/openfire/plugin/threaddump/evaluator/TaskEngineEvaluator.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/threaddump/evaluator/TaskEngineEvaluator.java
@@ -1,0 +1,80 @@
+package org.igniterealtime.openfire.plugin.threaddump.evaluator;
+
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.TaskEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class TaskEngineEvaluator implements Evaluator
+{
+    private static final Logger Log = LoggerFactory.getLogger( TaskEngineEvaluator.class );
+
+    private int successiveHits = 0;
+
+    @Override
+    public Duration getInterval()
+    {
+        final long backoffMS = JiveGlobals.getLongProperty( "threaddump.evaluator.taskengine.interval", Duration.of( 5, ChronoUnit.SECONDS ).toMillis() );
+        return Duration.of( backoffMS, ChronoUnit.MILLIS );
+    }
+
+    @Override
+    public boolean shouldCreateThreadDump()
+    {
+        Log.trace( "Evaluating..." );
+        if ( checkPool() )
+        {
+            Log.trace( "At least one statistic for the TaskEngine is at max. Increasing successive hit count." );
+            successiveHits++;
+            final int limit = JiveGlobals.getIntProperty( "threaddump.evaluator.taskengine.successive-hits", 2 );
+            if ( successiveHits >= limit )
+            {
+                Log.trace( "Successive hit count ({}) has hit limit ({}).", successiveHits, limit );
+                successiveHits = 0;
+                Log.debug( "Do create a thread dump." );
+                return true;
+            }
+        }
+        else
+        {
+            successiveHits = 0;
+        }
+
+        Log.debug( "No need to create a thread dump." );
+        return false;
+    }
+
+    protected boolean checkPool()
+    {
+        final int maxActiveCount = JiveGlobals.getIntProperty( "threaddump.evaluator.taskengine.max-threads", 300 );
+        final int maxPoolsize = JiveGlobals.getIntProperty( "threaddump.evaluator.taskengine.max-poolsize", 500 );
+
+        Field executorField = null;
+        try {
+            executorField = TaskEngine.class.getDeclaredField("executor"); //NoSuchFieldException
+            executorField.setAccessible(true);
+            final ThreadPoolExecutor executor = (ThreadPoolExecutor) executorField.get(TaskEngine.getInstance()); //IllegalAccessException
+            final int activeCount = executor.getActiveCount();
+            if (activeCount >= maxActiveCount) {
+                return true;
+            }
+
+            final int poolSize = executor.getPoolSize();
+            if (poolSize >= maxPoolsize) {
+                return true;
+            }
+        } catch ( Throwable t ) {
+            Log.warn("An exception occurred while trying to check the pool of TaskEngine.", t);
+        } finally {
+            if (executorField != null) {
+                executorField.setAccessible(false);
+            }
+        }
+        return false;
+    }
+}

--- a/src/readme.html
+++ b/src/readme.html
@@ -117,6 +117,16 @@ copy the new threaddump.jar file over the existing file.
         <tr><td><tt>threaddump.evaluator.deadlock.interval</tt></td><td>The frequence of deadlock detection evaluator.</td></tr>
     </table>
 </p>
+    </li><li>
+<p><tt style="color: black">org.igniterealtime.openfire.plugin.threaddump.evaluator.TaskEngineEvaluator</tt></p>
+<p>An evaluator that periodically checks the thread pool that is used by Openfire's internal Task Engine.
+    <table>
+        <tr><td><tt>threaddump.evaluator.taskengine.interval</tt></td><td>The frequency (in milliseconds) of task engine thread pool evaluation.</td></tr>
+        <tr><td><tt>threaddump.evaluator.taskengine.successive-hits</tt></td><td>How many successive evaluations must have detected excessive thread pool usage, for a thread dump to be created.</td></tr>
+        <tr><td><tt>threaddump.evaluator.taskengine.max-threads</tt></td><td>The minimum amount of active threads in the pool to trigger a thread dump.</td></tr>
+        <tr><td><tt>threaddump.evaluator.taskengine.max-poolsize</tt></td><td>The minimum size of the thread pool (including active and inactive threads) to trigger a thread dump.</td></tr>
+    </table>
+</p>
     </li>
 </ul>
 <h2>Attribution</h2>


### PR DESCRIPTION
Openfire has a TaskEngine implementation, that is a general purpose executor service. This implementation uses a thread pool. This plugin should include an evaluator that causes a thread dump to be created if this particular thread pool misbehaves.