### PR TITLE
fixes #9: add evaluator for database connection pool

### DIFF
--- a/src/changelog.html
+++ b/src/changelog.html
@@ -47,12 +47,13 @@ Threaddump Plugin Changelog
 
 <p><b>1.1.0</b> -- (tbd)</p>
 <ul>
-    <li>Added new evaluator for TaskEngine</li>
+    <li><a href="https://github.com/igniterealtime/openfire-threaddump-plugin/pull/9">Issue #9</a>: Added new evaluator for the database connection pool</li>
+    <li><a href="https://github.com/igniterealtime/openfire-threaddump-plugin/pull/6">Issue #6</a>: Added new evaluator for TaskEngine</li>
 </ul>
 
 <p><b>1.0.1</b> -- January 12, 2021</p>
 <ul>
-     <li><a href="https://github.com/igniterealtime/openfire-threaddump-plugin/pull/4">#4</a> Fix Maven groupId</li>
+     <li><a href="https://github.com/igniterealtime/openfire-threaddump-plugin/pull/4">Issue #4</a>: Fix Maven groupId</li>
 </ul>
 
 <p><b>1.0.0</b> -- August 2, 2019</p>

--- a/src/main/i18n/threaddump_i18n.properties
+++ b/src/main/i18n/threaddump_i18n.properties
@@ -20,12 +20,19 @@ threaddump.page.task.settings.header=Generic Settings
 threaddump.page.task.delay=The delay for starting the evaluation task that is observed after applying configuration changes or restarting the plugin.
 threaddump.page.task.interval=The frequency at which to check what evaluators are ready to be executed.
 threaddump.page.task.backoff=After a thread dump is generated, wait this period before allowing a new one to be generated.
+threaddump.page.task.unsupported-evaluator=The way in which this instance of Openfire is installed or configured is not compatible with this evaluator. It is disabled.
 
 threaddump.page.task.pools.title=Settings for evaluation of thread pools
 threaddump.page.task.pools.enabled=Generate a thread dump when the core network thread pools are very busy.
-threaddump.page.task.pools.busy-percentage=The percentage of threads in a pool that can be running at the same time that is considered 'busy'.
+threaddump.page.task.pools.busy-percentage-max=The percentage of threads in a pool that can be running at the same time that is considered 'busy'.
 threaddump.page.task.pools.interval=The frequency of core network thread pool evaluation.
 threaddump.page.task.pools.successive-hits=How many successive evaluations must have detected excessive thread pool usage, for a thread dump to be created.
+
+threaddump.page.task.dbpool.title=Settings for evaluation of the database connection pool
+threaddump.page.task.dbpool.enabled=Generate a thread dump when the database connection pool are very busy.
+threaddump.page.task.dbpool.busy-percentage-max=The percentage of database connections in the pool that can be running at the same time that is considered 'busy'.
+threaddump.page.task.dbpool.interval=The frequency of database connection pool evaluation.
+threaddump.page.task.dbpool.successive-hits=How many successive evaluations must have detected excessive database connection pool usage, for a thread dump to be created.
 
 threaddump.page.task.deadlock.title=Settings for evaluation of thread deadlocks
 threaddump.page.task.deadlock.enabled=Generate a thread dump when a deadlock is detected.

--- a/src/main/java/org/igniterealtime/openfire/plugin/threaddump/ThreadDumpPlugin.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/threaddump/ThreadDumpPlugin.java
@@ -15,10 +15,7 @@
  */
 package org.igniterealtime.openfire.plugin.threaddump;
 
-import org.igniterealtime.openfire.plugin.threaddump.evaluator.CoreThreadPoolsEvaluator;
-import org.igniterealtime.openfire.plugin.threaddump.evaluator.DeadlockEvaluator;
-import org.igniterealtime.openfire.plugin.threaddump.evaluator.Evaluator;
-import org.igniterealtime.openfire.plugin.threaddump.evaluator.TaskEngineEvaluator;
+import org.igniterealtime.openfire.plugin.threaddump.evaluator.*;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.util.JiveGlobals;
@@ -86,7 +83,11 @@ public class ThreadDumpPlugin implements Plugin, PropertyEventListener
                 try
                 {
                     final Evaluator evaluator = evaluatorClass.newInstance();
-                    evaluators.add( evaluator );
+                    if (evaluator.isSupported()) {
+                        evaluators.add(evaluator);
+                    } else {
+                        Log.info( "Not loading evaluator {} as its functionality is not supported by the configuration of this Openfire server.", evaluator.getClass().getSimpleName() );
+                    }
                 }
                 catch ( Exception e )
                 {
@@ -178,7 +179,7 @@ public class ThreadDumpPlugin implements Plugin, PropertyEventListener
     public Set<Class<? extends Evaluator>> getTaskEvaluatorClasses()
     {
         final Set<Class<? extends Evaluator>> result = new HashSet<>();
-        final String evaluatorNames = JiveGlobals.getProperty( "threaddump.task.evaluators", CoreThreadPoolsEvaluator.class.getCanonicalName() + ", " + DeadlockEvaluator.class.getCanonicalName() + ", " + TaskEngineEvaluator.class.getCanonicalName() );
+        final String evaluatorNames = JiveGlobals.getProperty( "threaddump.task.evaluators", CoreThreadPoolsEvaluator.class.getCanonicalName() + ", " + DeadlockEvaluator.class.getCanonicalName() + ", " + TaskEngineEvaluator.class.getCanonicalName() + ", " + DatabaseConnectionPoolEvaluator.class.getCanonicalName());
         if ( evaluatorNames != null ) {
             for ( final String evaluatorName : evaluatorNames.split( "\\s*,\\s*" ) )
             {

--- a/src/main/java/org/igniterealtime/openfire/plugin/threaddump/evaluator/CoreThreadPoolsEvaluator.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/threaddump/evaluator/CoreThreadPoolsEvaluator.java
@@ -56,7 +56,7 @@ public class CoreThreadPoolsEvaluator implements Evaluator
 
     protected boolean checkPools()
     {
-        final int busyPercentageLimit = JiveGlobals.getIntProperty( "threaddump.evaluator.threadpools.busy-percentage", 90 );
+        final int busyPercentageLimit = JiveGlobals.getIntProperty( "threaddump.evaluator.threadpools.busy-percentage-max", 90 );
         final Set<ConnectionListener> listeners = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager()).getListeners();
         for ( ConnectionListener listener : listeners )
         {

--- a/src/main/java/org/igniterealtime/openfire/plugin/threaddump/evaluator/DatabaseConnectionPoolEvaluator.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/threaddump/evaluator/DatabaseConnectionPoolEvaluator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.openfire.plugin.threaddump.evaluator;
+
+import org.jivesoftware.database.ConnectionProvider;
+import org.jivesoftware.database.DbConnectionManager;
+import org.jivesoftware.database.DefaultConnectionProvider;
+import org.jivesoftware.database.EmbeddedConnectionProvider;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.TaskEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class DatabaseConnectionPoolEvaluator implements Evaluator
+{
+    private static final Logger Log = LoggerFactory.getLogger(DatabaseConnectionPoolEvaluator.class);
+
+    private int successiveHits = 0;
+
+    @Override
+    public Duration getInterval()
+    {
+        final long backoffMS = JiveGlobals.getLongProperty( "threaddump.evaluator.dbpool.interval", Duration.of( 5, ChronoUnit.SECONDS ).toMillis() );
+        return Duration.of( backoffMS, ChronoUnit.MILLIS );
+    }
+
+    @Override
+    public boolean shouldCreateThreadDump()
+    {
+        Log.trace( "Evaluating..." );
+        if ( checkPool() )
+        {
+            Log.trace( "At least one statistic for the TaskEngine is at max. Increasing successive hit count." );
+            successiveHits++;
+            final int limit = JiveGlobals.getIntProperty( "threaddump.evaluator.dbpool.successive-hits", 2 );
+            if ( successiveHits >= limit )
+            {
+                Log.trace( "Successive hit count ({}) has hit limit ({}).", successiveHits, limit );
+                successiveHits = 0;
+                Log.debug( "Do create a thread dump." );
+                return true;
+            }
+        }
+        else
+        {
+            successiveHits = 0;
+        }
+
+        Log.debug( "No need to create a thread dump." );
+        return false;
+    }
+
+    protected boolean checkPool()
+    {
+        final int busyPercentageLimit = JiveGlobals.getIntProperty( "threaddump.evaluator.dbpool.busy-percentage-max", 90 );
+
+        final ConnectionProvider connectionProvider = DbConnectionManager.getConnectionProvider();
+        if (isSupported()) {
+            final DefaultConnectionProvider defaultConnectionProvider = (DefaultConnectionProvider) connectionProvider;
+            final int activeConnections = defaultConnectionProvider.getActiveConnections();
+            final int maxConnections = defaultConnectionProvider.getMaxConnections();
+            final int busyPercentage = 100 * activeConnections / maxConnections;
+            Log.trace( "{}% ({}/{}) connections of database pool are currently active. Threshold: {}%", new Object[] { busyPercentage, activeConnections, maxConnections, busyPercentageLimit });
+            return busyPercentage > busyPercentageLimit;
+        } else {
+            Log.debug("This server is using {} as the database connection provider for Openfire, which is not supported by this evaluator.", connectionProvider.getClass().getSimpleName());
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isSupported() {
+        return DbConnectionManager.getConnectionProvider() instanceof DefaultConnectionProvider && DbConnectionManager.getConnectionProvider().isPooled();
+    }
+}

--- a/src/main/java/org/igniterealtime/openfire/plugin/threaddump/evaluator/Evaluator.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/threaddump/evaluator/Evaluator.java
@@ -6,4 +6,7 @@ public interface Evaluator
 {
     Duration getInterval();
     boolean shouldCreateThreadDump();
+    default boolean isSupported() {
+        return true;
+    }
 }

--- a/src/plugin.xml
+++ b/src/plugin.xml
@@ -6,7 +6,7 @@
     <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>01/12/2021</date>
+    <date>2022-08-30</date>
 
     <adminconsole>
         <tab id="tab-server">

--- a/src/readme.html
+++ b/src/readme.html
@@ -111,6 +111,15 @@ copy the new threaddump.jar file over the existing file.
     </table>
 </p>
     </li><li>
+    <p><tt style="color: black">org.igniterealtime.openfire.plugin.threaddump.evaluator.DatabaseConnectionPoolEvaluator</tt></p>
+    <p>An evaluator that periodically checks the amount of active database connections in the pool that manages the total amount of available connections. This evaluator is only available when using the standard database connection provider. It does not support the embedded database.
+    <table>
+        <tr><td><tt>threaddump.evaluator.dbpool.interval</tt></td><td>The frequency (in milliseconds) of database connection pool evaluation.</td></tr>
+        <tr><td><tt>threaddump.evaluator.dbpool.busy-percentage-max</tt></td><td>The percentage of connections in the pool that can be running at the same time that is considered 'busy'.</td></tr>
+        <tr><td><tt>threaddump.evaluator.dbpool.successive-hits</tt></td><td>How many successive evaluations must have detected excessive connection pool usage, for a thread dump to be created.</td></tr>
+    </table>
+</p>
+</li><li>
 <p><tt style="color: black">org.igniterealtime.openfire.plugin.threaddump.evaluator.DeadlockEvaluator</tt></p>
 <p>An evaluator that periodically checks if a thread deadlock has occurred.
     <table>


### PR DESCRIPTION
A new evaluator has been added that will cause a thread dump to be generated when the database connection pool usage is above a configurable threshold.